### PR TITLE
mata: Add excluded-input-devices.xml from stock

### DIFF
--- a/configs/excluded-input-devices.xml
+++ b/configs/excluded-input-devices.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- Copyright (c) 2017 The Linux Foundation. All rights reserved.          -->
+<!--                                                                        -->
+<!-- Redistribution and use in source and binary forms, with or without     -->
+<!-- modification, are permitted provided that the following conditions are -->
+<!-- met:                                                                   -->
+<!--     * Redistributions of source code must retain the above copyright   -->
+<!--       notice, this list of conditions and the following disclaimer.    -->
+<!--     * Redistributions in binary form must reproduce the above          -->
+<!--       copyright notice, this list of conditions and the following      -->
+<!--       disclaimer in the documentation and/or other materials provided  -->
+<!--       with the distribution.                                           -->
+<!--     * Neither the name of The Linux Foundation nor the names of its    -->
+<!--       contributors may be used to endorse or promote products derived  -->
+<!--       from this software without specific prior written permission.    -->
+<!--                                                                        -->
+<!-- THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED           -->
+<!-- WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF   -->
+<!-- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT -->
+<!-- ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS -->
+<!-- BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR -->
+<!-- CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF   -->
+<!-- SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR        -->
+<!-- BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,  -->
+<!-- WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE   -->
+<!-- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN -->
+<!-- IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                          -->
+<devices>
+    <device name="STM VL53L0 proximity sensor" />
+</devices>

--- a/device.mk
+++ b/device.mk
@@ -328,6 +328,9 @@ PRODUCT_PACKAGES += \
     android.hardware.sensors@1.0-impl:64 \
     android.hardware.sensors@1.0-service
 
+PRODUCT_COPY_FILES += \
+    device/essential/mata/configs/excluded-input-devices.xml:$(TARGET_COPY_OUT_SYSTEM)/etc/excluded-input-devices.xml
+
 # Soong
 PRODUCT_SOONG_NAMESPACES += \
     device/essential/mata \

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -791,14 +791,14 @@ vendor/lib/libsensor1.so
 vendor/lib/libsensor_reg.so
 vendor/lib/libsns_low_lat_stream_stub.so
 vendor/lib/sensor_calibrate.so
-vendor/lib/sensors.hal.tof.so|7026ad35d4e644e0de8c5168e82a5aaf80ce7145
+vendor/lib/sensors.hal.tof.so
 vendor/lib/sensors.mata.so
 vendor/lib64/hw/activity_recognition.msm8998.so
 vendor/lib64/libsensor1.so
 vendor/lib64/libsensor_reg.so
 vendor/lib64/libsns_low_lat_stream_stub.so
 vendor/lib64/sensor_calibrate.so
-vendor/lib64/sensors.hal.tof.so|80d754f5eec132a15771b88386b79fb21cf1f44a
+vendor/lib64/sensors.hal.tof.so
 vendor/lib64/sensors.mata.so
 
 # Thermal


### PR DESCRIPTION
* This fixes the multitouch bug without the need for hex-editing
* This works by telling InputManager to ignore all input events
  from the sensors specified in the xml, which is important because
  our TOF (laser AF) sensor reports ABS_PRESSURE events, which
  InputManager misinterprets at the moment, breaking multitouch

This reverts commit 998a87ad1c4ec2a454e2612f60baf67f1177dfcc.